### PR TITLE
messageオプションを追加（Add --message option）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# バイナリファイル
+/bin/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# テストバイナリ
+*.test
+
+# カバレッジファイル
+*.out
+*.prof
+
+# 依存関係のキャッシュ
+/vendor/
+/go.work
+
+# OS固有のファイル
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# エディタ固有のファイル
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# ログファイル
+*.log
+
+# 環境変数ファイル
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# その他の一時ファイル
+/tmp/
+*.tmp

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SaGaCLI is a simple yet powerful command-line interface for leveraging Large Lan
 ## Features
 
 - **Multiple LLM Support**: Use OpenAI (GPT-3.5/GPT-4), Claude (Anthropic), or Gemini (Google) models
-- **Diverse Functions**: Translation, summarization, explanation, search, and more
+- **Diverse Functions**: Translation, summarization, explanation, search, custom messages, and more
 - **Flexible Input**: Accept text from file paths or standard input
 - **Multilingual Support**: Specify any target language for output
 
@@ -116,6 +116,7 @@ Enter your text...
 --summary      # Summarization mode
 --explanation  # Explanation mode
 --search       # Search mode
+--message      # Custom message mode (send specific instructions)
 --lang [language_code]  # Specify output language (e.g., en, ja, fr, zh, etc.)
 ```
 
@@ -133,6 +134,12 @@ $ cat code.py | saga --explanation --lang en
 
 # Search for information on a specific topic
 $ echo "Quantum computing basics" | saga --search --lang en
+
+# Extract name field from JSON data
+$ cat document.json | saga --message "Extract the name value" --lang en
+
+# Calculate average of age column in CSV data
+$ cat document.csv | saga --message "Calculate the average of the age column" --lang en
 
 # Translate a document to Japanese then summarize it
 $ cat english_doc.txt | saga --translation --lang ja | saga --summary --lang ja

--- a/README_ja.md
+++ b/README_ja.md
@@ -5,7 +5,7 @@ Golangで書かれたコマンドラインインターフェースです。
 ## 特徴
 
 - **複数のLLMサポート**: OpenAI（GPT-3.5/GPT-4）、AnthropicのClaude（Claude-3シリーズ）、GoogleのGemini（Gemini-2.5-pro）をサポート
-- **多様な機能**: 翻訳、要約、解説、検索など、さまざまな機能を提供
+- **多様な機能**: 翻訳、要約、解説、検索、カスタムメッセージなど、さまざまな機能を提供
 - **柔軟な入力**: ファイルパスまたは標準入力からテキストを受け付け
 - **多言語対応**: 出力言語を自由に指定可能
 
@@ -116,6 +116,7 @@ $ saga [オプション]
 --summary      # 要約モード
 --explanation  # 解説モード
 --search       # 検索モード
+--message      # カスタムメッセージモード（特定の指示を送信）
 --lang [言語コード]  # 出力言語の指定（例: ja, en, fr, zh など）
 ```
 
@@ -133,6 +134,12 @@ $ cat code.py | saga --explanation --lang ja
 
 # 特定のトピックについて検索
 $ echo "量子コンピューティングの基本原理" | saga --search --lang ja
+
+# JSONデータからnameフィールドの値を抽出
+$ cat document.json | saga --message "nameの値を取り出して" --lang ja
+
+# CSVファイルの年齢列の平均を計算
+$ cat document.csv | saga --message "年齢の列の平均を計算して" --lang ja
 
 # 英語のドキュメントを翻訳して日本語で要約
 $ cat english_doc.txt | saga --translation --lang ja | saga --summary --lang ja

--- a/cmd/saga/cmd/root.go
+++ b/cmd/saga/cmd/root.go
@@ -20,6 +20,7 @@ var (
 	isSummary     bool
 	isExplanation bool
 	isSearch      bool
+	messageFlag   string
 	langFlag      string
 
 	// RootCmd はCLIツールのルートコマンド
@@ -38,6 +39,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&isSummary, "summary", false, "入力されたテキストを要約します")
 	RootCmd.PersistentFlags().BoolVar(&isExplanation, "explanation", false, "入力されたテキストを解説します")
 	RootCmd.PersistentFlags().BoolVar(&isSearch, "search", false, "入力されたテキストに基づいて情報を検索します")
+	RootCmd.PersistentFlags().StringVar(&messageFlag, "message", "", "入力データに対して実行したい操作を指定します")
 	RootCmd.PersistentFlags().StringVar(&langFlag, "lang", "en", "出力言語を指定します（例: en, ja, fr）")
 
 	// 環境変数の設定を読み込む
@@ -100,8 +102,10 @@ func rootRun(cmd *cobra.Command, args []string) {
 		service = services.NewExplanationService(llmClient, langFlag)
 	case isSearch:
 		service = services.NewSearchService(llmClient, langFlag)
+	case messageFlag != "":
+		service = services.NewMessageService(llmClient, langFlag, messageFlag)
 	default:
-		fmt.Fprintf(os.Stderr, "機能フラグが指定されていません。--translation, --summary, --explanation, --searchのいずれかを指定してください。\n")
+		fmt.Fprintf(os.Stderr, "機能フラグが指定されていません。--translation, --summary, --explanation, --search, --messageのいずれかを指定してください。\n")
 		os.Exit(1)
 	}
 

--- a/pkg/services/message.go
+++ b/pkg/services/message.go
@@ -1,0 +1,33 @@
+// filepath: /home/soudai/work/hft/saga-cli/pkg/services/message.go
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sa-giga/saga-cli/pkg/llm"
+)
+
+// MessageService はユーザー指定メッセージに基づいた処理サービスを提供します
+type MessageService struct {
+	llmClient llm.LLM
+	lang      string
+	message   string
+}
+
+// NewMessageService は新しいメッセージサービスを作成します
+func NewMessageService(llmClient llm.LLM, lang string, message string) *MessageService {
+	return &MessageService{
+		llmClient: llmClient,
+		lang:      lang,
+		message:   message,
+	}
+}
+
+// Process はユーザー指定のメッセージに基づいて入力テキストを処理します
+func (s *MessageService) Process(ctx context.Context, inputText string) (string, error) {
+	systemPrompt := fmt.Sprintf("以下の入力データに対して、指示に従ってタスクを実行してください。回答は%sで提供してください。", s.lang)
+	userPrompt := fmt.Sprintf("【指示】\n%s\n\n【入力データ】\n%s", s.message, inputText)
+
+	return s.llmClient.Complete(ctx, systemPrompt, userPrompt)
+}


### PR DESCRIPTION
#3 の対応として、saga-cliに --message オプションを追加しました。

## 変更内容
- `--message` オプションを追加
- MessageServiceの実装を追加
- READMEとREADME_ja.mdのドキュメントを更新

## 使用例
```bash
# JSONデータからnameフィールドの値を抽出
cat document.json | saga --message "nameの値を取り出して" --lang ja

# CSVファイルの年齢列の平均を計算
cat document.csv | saga --message "年齢の列の平均を計算して" --lang ja